### PR TITLE
프론트엔드 빌드 파이프라인 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "test": "npm run frontend:test",
-    "start": "npm run backend:run",
-    "frontend:build": "webpack",
-    "frontend:style": "mkdir -p frontend/assets/css && node-sass --output-style compressed frontend/assets/scss/styles.scss > frontend/assets/css/style.css",
-    "frontend:build-prod": "cross-env BUILD_ENV=production webpack",
-    "frontend:test": "jest",
-    "backend:run": "make run"
+    "start": "make run"
   },
   "license": "MIT",
   "devDependencies": {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -16,6 +16,9 @@ module.exports = {
       }
     ]
   },
+  watchOptions: {
+    ignored: /node_modules/
+  },
   devtool: 'source-map',
   mode: process.env.MINDPILL_ENV === 'production' ? 'production' : 'development'
 }


### PR DESCRIPTION
#2 에서 빼먹은 몇가지 사항을 추가하기 위한 PR.

1. 필요 없어진 `frontend.go`가 생성되지 않도록 `Makefile` 수정
2. Webpack에 `--watch` 옵션을 줘서 실행할 때 `node_module` 디렉토리를 바라보지 않도록 수정