### PR TITLE
frontend: SSR 환경에서 로그 출력이 가능하도록 변경

### DIFF
--- a/frontend/src/lib/log.ts
+++ b/frontend/src/lib/log.ts
@@ -1,0 +1,21 @@
+const isBrowser: boolean =
+  typeof window !== 'undefined' &&
+  window.document != null &&
+  window.document.createElement != null
+
+const log = (...args: any) => {
+  if (isBrowser) {
+    console.log(...args)
+  } else {
+    console.error(...args)
+  }
+}
+
+const error = (...args: any) => {
+  console.error(...args)
+}
+
+const logger = { log, error }
+
+export default logger
+export { log, error }


### PR DESCRIPTION
1. 백엔드에서 SSR 프로세스를 실행할 때 stderr 출력을 버퍼에 담아두었다가 렌더링 완료 후 출력하도록 변경.
2. 프론트에서 사용할 수 있는 `log.ts` 라이브러리 추가